### PR TITLE
GIF_begin build failure fix, etc.

### DIFF
--- a/linux/main.c
+++ b/linux/main.c
@@ -1,6 +1,5 @@
 //
 //  main.cpp
-//  jpeg_test
 //
 //  Created by Laurence Bank on 8/2/20.
 //  Copyright © 2020 Laurence Bank. All rights reserved.

--- a/linux/main.c
+++ b/linux/main.c
@@ -21,7 +21,7 @@ int rc, iFrame;
     printf("Animated GIF Linux Demo\n");
     printf("Run with no parameters to test in-memory decoding\n");
     printf("Or pass a filename on the command line\n\n");
-    GIF_begin(&gif, BIG_ENDIAN_PIXELS);
+    GIF_begin(&gif, BIG_ENDIAN_PIXELS, GIF_PALETTE_RGB888);
     printf("Starting GIF decoder...\n");
     if (argc == 2) // use filename
         rc = GIF_openFile(&gif, argv[1], GIFDraw);

--- a/src/AnimatedGIF.h
+++ b/src/AnimatedGIF.h
@@ -46,6 +46,11 @@
 #define MAX_HASH 5003
 #define MAXMAXCODE 4096
 
+// Validate GIF Defines configuration
+#if !(FILE_BUF_SIZE >= MAX_CHUNK_SIZE)
+# error "FILE_BUF_SIZE must be >= MAX_CHUNK_SIZE"
+#endif
+
 // RGB565 pixel byte order in the palette
 #define BIG_ENDIAN_PIXELS 0
 #define LITTLE_ENDIAN_PIXELS 1

--- a/src/gif.c
+++ b/src/gif.c
@@ -36,9 +36,11 @@ static int32_t readMem(GIFFILE *pFile, uint8_t *pBuf, int32_t iLen);
 static int32_t seekMem(GIFFILE *pFile, int32_t iPosition);
 int GIFGetInfo(GIFIMAGE *pPage, GIFINFO *pInfo);
 #if defined( PICO_BUILD ) || defined( __LINUX__ ) || defined( __MCUXPRESSO )
+#if !defined( PICO_BUILD )
 static int32_t readFile(GIFFILE *pFile, uint8_t *pBuf, int32_t iLen);
 static int32_t seekFile(GIFFILE *pFile, int32_t iPosition);
 static void closeFile(void *handle);
+#endif
 
 // C API
 int GIF_openRAM(GIFIMAGE *pGIF, uint8_t *pData, int iDataSize, GIF_DRAW_CALLBACK *pfnDraw)


### PR DESCRIPTION
Functional changes:
```
linux/main.c: too few arguments to function ‘GIF_begin’ #30
Validate GIF Defines configuration
```
(plus some warnings and a cosmetic cleanups)
