### PR TITLE
Identify Trailer Byte as end of GIF data stream

### DIFF
--- a/src/gif.inl
+++ b/src/gif.inl
@@ -392,6 +392,11 @@ static int GIFParseInfo(GIFIMAGE *pPage, int bInfoOnly)
                     return 0;
             } /* switch */
         }
+        else if (p[iOffset] == ';') // Trailer Byte, End of the GIF Data Stream
+        {
+            pPage->iError = GIF_EMPTY_FRAME;
+            return 0;
+        }
         else // invalid byte, stop decoding
         {
             if (pPage->GIFFile.iSize - iStartPos < 32) // non-image bytes at end of file?


### PR DESCRIPTION
...instead of just guessing when we're at the end of the file.  Fixes #38 

It's possible that the code to detect non-image data at the end of the GIF is now redundant.  I searched but couldn't find a GitHub Issue that contained GIFs that require this logic to test if they now parse with that code removed.  It doesn't really hurt to leave it in.

https://github.com/bitbank2/AnimatedGIF/commit/0e6780f96969ee3bf71ea0fa383e25453399f18a