### PR TITLE
Add global/local palette information to GIFDRAW

### DIFF
--- a/src/AnimatedGIF.h
+++ b/src/AnimatedGIF.h
@@ -110,6 +110,7 @@ typedef struct gif_draw_tag
     uint8_t ucHasTransparency; // flag indicating the transparent color is in use
     uint8_t ucDisposalMethod; // frame disposal method
     uint8_t ucBackground; // background color
+    bool bIsGlobalPalette; // Flag to indicate that a global palette, rather than a local palette is being used
 } GIFDRAW;
 
 // Callback function prototypes

--- a/src/AnimatedGIF.h
+++ b/src/AnimatedGIF.h
@@ -110,7 +110,7 @@ typedef struct gif_draw_tag
     uint8_t ucHasTransparency; // flag indicating the transparent color is in use
     uint8_t ucDisposalMethod; // frame disposal method
     uint8_t ucBackground; // background color
-    bool bIsGlobalPalette; // Flag to indicate that a global palette, rather than a local palette is being used
+    uint8_t ucIsGlobalPalette; // Flag to indicate that a global palette, rather than a local palette is being used
 } GIFDRAW;
 
 // Callback function prototypes

--- a/src/gif.inl
+++ b/src/gif.inl
@@ -863,6 +863,7 @@ static void GIFMakePels(GIFIMAGE *pPage, unsigned int code)
             gd.pPixels = pPage->ucLineBuf;
             gd.pPalette = (pPage->bUseLocalPalette) ? pPage->pLocalPalette : pPage->pPalette;
             gd.pPalette24 = (uint8_t *)gd.pPalette; // just cast the pointer for RGB888
+            gd.bIsGlobalPalette = !(pPage->bUseLocalPalette);
             gd.y = pPage->iHeight - pPage->iYCount;
             // Ugly logic to handle the interlaced line position, but it
             // saves having to have another set of state variables

--- a/src/gif.inl
+++ b/src/gif.inl
@@ -863,7 +863,7 @@ static void GIFMakePels(GIFIMAGE *pPage, unsigned int code)
             gd.pPixels = pPage->ucLineBuf;
             gd.pPalette = (pPage->bUseLocalPalette) ? pPage->pLocalPalette : pPage->pPalette;
             gd.pPalette24 = (uint8_t *)gd.pPalette; // just cast the pointer for RGB888
-            gd.bIsGlobalPalette = !(pPage->bUseLocalPalette);
+            gd.ucIsGlobalPalette = pPage->bUseLocalPalette==1?0:1;
             gd.y = pPage->iHeight - pPage->iYCount;
             // Ugly logic to handle the interlaced line position, but it
             // saves having to have another set of state variables


### PR DESCRIPTION
Hi,

Thank you for this library!

I just thought I'd add a small change to the library to indicate whether the palette that's being passed to the drawing callback function is a global palette or a local one. The reason is that I have an application where I want to manipulate the palette every few frames, and I need to differentiate between the two types of palette. I couldn't find an obvious way to do it other than to add a flag to GIFDRAW to say it's one or the other.

I hope you find this minor change useful.

Cheers,
welshcoder