### PR TITLE
fix memory corruption if MAX_CODE_SIZE<12 

### DIFF
--- a/src/AnimatedGIF.h
+++ b/src/AnimatedGIF.h
@@ -52,7 +52,17 @@
 // with 256 entries
 //
 #define TURBO_BUFFER_SIZE 0x6100
+
+// If you intend to decode generic GIFs, you want this value to be 12. If you are using GIFs solely for animations in
+// your own project, and you control the GIFs you intend to play, then you can save additional RAM here: 
+// the decoder must reserve a minimum of 4 byte * (1<<MAX_CODE_SIZE) for the dictionary, but based on implementation
+// actually reserves 5 byte * (1<<MAX_CODE_SIZE). Small or low colour GIFs may inherently not require a large
+// dictionary. For larger GIFs, the en(!)coder can "voluntarily" choose not to utilize the entire dictionary. I.e.,
+// by preparing (specially encoding) the GIFs, you can save >10kB RAM, but you will not be able to decode arbitrary
+// images anymore. One application to craft such GIFs can be found here (use option -d) 
+// https://create.stephan-brumme.com/flexigif-lossless-gif-lzw-optimization/
 #define MAX_CODE_SIZE 12
+
 #define MAX_COLORS 256
 #ifdef __LINUX__
 #define MAX_WIDTH 2048

--- a/src/gif.inl
+++ b/src/gif.inl
@@ -1455,11 +1455,8 @@ init_codetable:
                     gifpels[PIXEL_LAST + nextcode] = c = gifpels[PIXEL_FIRST + code];
                 }
                 nextcode++;
-                if (nextcode >= nextlim)
+                if (nextcode >= nextlim && codesize < MAX_CODE_SIZE)
                 {
-                    if (codesize >= MAX_CODE_SIZE)
-                        return -1; // error. encoder assumed a larger dictionary than we can accommodate. decoding
-                                   // the remainder of the image would be unpredictable and possibly dangerous
                     codesize++;
                     nextlim <<= 1;
                     sMask = nextlim - 1;

--- a/src/gif.inl
+++ b/src/gif.inl
@@ -1431,7 +1431,7 @@ init_codetable:
     nextcode = cc + 2;
     nextlim = (unsigned short) ((1 << codesize));
     // This part of the table needs to be reset multiple times
-    memset(&giftabs[cc], LINK_UNUSED, (4096 - cc)*sizeof(short));
+    memset(&giftabs[cc], LINK_UNUSED, sizeof(pImage->usGIFTable) - sizeof(giftabs[0])*cc);
     ulBits = INTELLONG(&p[pImage->iLZWOff]); // start by reading 4 bytes of LZW data
     GET_CODE
     if (code == cc) // we just reset the dictionary, so get another code
@@ -1455,8 +1455,11 @@ init_codetable:
                     gifpels[PIXEL_LAST + nextcode] = c = gifpels[PIXEL_FIRST + code];
                 }
                 nextcode++;
-                if (nextcode >= nextlim && codesize < MAX_CODE_SIZE)
+                if (nextcode >= nextlim)
                 {
+                    if (codesize >= MAX_CODE_SIZE)
+                        return -1; // error. encoder assumed a larger dictionary than we can accommodate. decoding
+                                   // the remainder of the image would be unpredictable and possibly dangerous
                     codesize++;
                     nextlim <<= 1;
                     sMask = nextlim - 1;


### PR DESCRIPTION
This would fix an issue if a user chose a smaller memory footprint by #define MAX_CODE_SIZE below 12. 

Depending on the project, AnimatedGIF approaches the RAM capacity of a SAMD21 microcontrollers. If you will be decoding small GIFs solely for project-internal animations, then there is an opportunity to get a >10kB headroom by specially encoding the GIFs with a smaller dictionary.

The decoder was clearing memory for a MAX_CODE_SIZE  of 12 bit regardless, though. There's a possibly similar magic value in the turbo code (I didn't touch it) although it is unlikely that a user would choose turbo mode but with a smaller dictionary.